### PR TITLE
Illegal characters in attribute fixed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export default {
   hooks: {
     preRender: function(next) {
       this.defs += markers;
-      this.attributes.add(`freesewing:${name}`, version);
+      this.attributes.add('freesewing:plugin-grainline', version);
       next();
     }
   },


### PR DESCRIPTION
The plugin version is added to the SVG attributes. The name of this attribute contained illegal characters `@ ` and `/`. I fixed the name by setting it to `plugin-grainline`. This is in line with how `cut-on-fold` sets it's name,